### PR TITLE
docs: add Hyper3D Rodin nodes to 3D category

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The repository serves as directory for nodes created for Griptape Nodes.
 
 ## 🛹 Griptape team contributed nodes
 
+### 🎲 3D
+
+* [Hyper3D Rodin](https://github.com/griptape-ai/griptape-nodes-library-rodin) - generate 3D models from text prompts or images using Hyper3D's Rodin API with support for text-to-3D, image-to-3D, multi-image generation, and multiple output formats (GLB/USDZ)
+
 ### 🖼️ Image
 
 * [Black Forest Labs](https://github.com/griptape-ai/griptape-nodes-library-blackforestlabs) - interact with Black Forest Labs' FLUX APIs, enabling high-quality image generation and editing capabilities


### PR DESCRIPTION
## Description

This PR adds the Hyper3D Rodin nodes library to the README in the new 3D category.

## Node Details

**Hyper3D Rodin** ([griptape-nodes-library-rodin](https://github.com/griptape-ai/griptape-nodes-library-rodin)):
- Text-to-3D generation from text prompts
- Image-to-3D generation from single or multiple images (up to 5)
- Multiple output formats: GLB and USDZ
- Quality control with multiple levels and mesh optimization
- Advanced options: bounding box constraints, pose control, material settings (PBR/Blinn-Phong)

## Motivation and Context

The Hyper3D Rodin library provides 3D model generation capabilities using the Hyper3D Rodin API. This is the first entry in the new 3D category, expanding the directory to cover 3D asset generation alongside existing image, video, and audio capabilities.

## How Has This Been Tested?

- [x] Verified markdown syntax is correct
- [x] Checked that description accurately reflects the features documented in the Rodin library README
- [x] Confirmed entry is in the correct category (3D)

## Types of changes 
- [x] Add new node to Directory
- [ ] Documentation update
- [ ] Add new Node Development resources 

# Checklist
- [x] I have read the Node Development Documentation (coming soon) 
- [x] My changes follows Node Development security best practices (coming soon)
- [x] I have added a detailed README.md to the repository containing the node
- [x] I have tested this with the latest version of Griptape Nodes
- [x] My contribution follows the repository's style
- [x] I have added appropriate error handling to the node
- [x] I have documented all environment variables and configuration options required for the node