### PR TITLE
feat: Add ElevenLabs library to audio section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The repository serves as directory for nodes created for Griptape Nodes.
 ## Node Development Guide
 
 If you’re building your own nodes or node libraries, start with the official guide:
+
 - **[Griptape Nodes Node Development Guide](https://github.com/griptape-ai/griptape-nodes-node-development-guide)**
 
 ## 🛹 Griptape team contributed nodes
@@ -84,6 +85,10 @@ If you’re building your own nodes or node libraries, start with the official g
   <p align="right"><a href="https://nodes.griptape.ai/#library-management?git=https://github.com/griptape-ai/griptape-nodes-library-topazlabs"><img src="images/add_to_griptape_nodes.png" width="150" alt="Add to Griptape Nodes"></a></p>
 
 ### 🎵 Audio
+
+- **[ElevenLabs](https://github.com/griptape-ai/griptape-nodes-library-elevenlabs)** - high-quality text-to-speech, voice cloning, voice design, voice changer, sound effects generation, and music generation using ElevenLabs' API
+
+  <p align="right"><a href="https://nodes.griptape.ai/#library-management?git=https://github.com/griptape-ai/griptape-nodes-library-elevenlabs"><img src="images/add_to_griptape_nodes.png" width="150" alt="Add to Griptape Nodes"></a></p>
 
 - **[Google AI](https://github.com/griptape-ai/griptape-nodes-library-googleai)** - generate 30-second instrumental music using Google's Lyria model with creative prompt guidance and copyright protection
 


### PR DESCRIPTION
## Description

Adds the ElevenLabs node library to the directory README under the Audio section. This library provides Griptape nodes for interacting with the ElevenLabs API.

## Node Details

The [ElevenLabs library](https://github.com/griptape-ai/griptape-nodes-library-elevenlabs) includes nodes for:
- **Text-to-Speech**: Generate natural-sounding speech from text with multiple voice options
- **Voice Changer**: Transform audio from one voice to another using speech-to-speech technology
- **Voice Cloning**: Clone voices from audio samples using Instant Voice Cloning
- **Voice Design**: Create custom voices from descriptive prompts
- **Sound Effects**: Generate sound effects from text descriptions
- **Music Generation**: Generate music from text prompts
- **Voice Management**: List and manage ElevenLabs voices

## Motivation and Context

The ElevenLabs library is a new Griptape team-contributed node library that should be listed in the directory so users can discover and install it.

## How Has This Been Tested?

- [x] The ElevenLabs library has been manually tested to ensure functionality
- [x] README links verified to point to correct repository
- [x] Install link format matches existing entries in the directory

## Types of changes 
* [x] Add new node to Directory
* [ ] Documentation update
* [ ] Add new Node Development resources 

# Checklist
* [x] I have read the Node Development Documentation (coming soon) 
* [ ] My changes follows Node Development security best practices (coming soon)
* [x] I have added a detailed README.md to the repository containing the node
* [x] I have tested this with the latest version of Griptape Nodes
* [x] My contribution follows the repository's style
* [x] I have added appropriate error handling to the node
* [x] I have documented all environment variables and configuration options required for the node