### PR TITLE
Add Modular Diffusers library with Labs marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ If you’re building your own nodes or node libraries, start with the official g
 
 - **[Griptape Nodes Node Development Guide](https://github.com/griptape-ai/griptape-nodes-node-development-guide)**
 
+> 🧪 marks a Labs library — experimental and under active development. Expect breaking changes.
+
 ## 🛹 Griptape team contributed nodes
+
+### 🏗️ Foundations
+
+- 🧪 **[Modular Diffusers](https://github.com/griptape-ai/griptape-nodes-library-diffusers)** - compose image and video generation workflows from modular Diffusers pipeline stages — build a pipeline once, then chain, branch, or reorder the individual noise, diffuse, transform, and decode steps as nodes. Supports Flux, SDXL, Qwen-Image, Z-Image, LTX, and WAN, with LoRA and ControlNet.
+
+  <p align="right"><a href="https://nodes.griptape.ai/#library-management?git=https://github.com/griptape-ai/griptape-nodes-library-diffusers"><img src="images/add_to_griptape_nodes.png" width="150" alt="Add to Griptape Nodes"></a></p>
 
 ### 🎲 3D
 


### PR DESCRIPTION
## Description

Adds the [Modular Diffusers](https://github.com/griptape-ai/griptape-nodes-library-diffusers) library to the directory and introduces two new conventions:

- **🧪 Labs marker + legend** — a one-line legend near the top of the README and a `🧪` prefix on the entry itself, to signal libraries that are experimental / under active development. The Diffusers library's own README flags itself as "⚠️ Experimental — under active development," so it's the natural first user of the marker.
- **🏗️ Foundations section** — a new top-level sub-section under `🛹 Griptape team contributed nodes`, above `🎲 3D`. Frames the library as foundational infrastructure rather than a modality-specific vendor wrapper.

## Node Details

Modular Diffusers exposes the stages of a Diffusers pipeline (build → latents → diffuse → transform → decode) as composable Griptape nodes. It spans both image (Flux, Flux2, SDXL, Qwen-Image, Z-Image) and video (LTX, LTX-2.x, WAN) models, with LoRA and ControlNet support.

## Motivation and Context

Resolves #26.

The library is architecturally distinct from other directory entries — it isn't a wrapper around one vendor's API, and it spans both image and video. Placing it under `🖼️ Image` or `🎥 Video` alone would undersell its scope; the new `🏗️ Foundations` section captures the "composable primitives" story more accurately.

## How Has This Been Tested?

Rendered the diff on GitHub — the legend blockquote and new section render cleanly, the "Add to Griptape Nodes" button block matches the format used by every other entry, and the link resolves to the correct repo.

## Types of changes
* [x] Add new node to Directory
* [ ] Documentation update
* [ ] Add new Node Development resources

# Checklist
* [x] My contribution follows the repository's style